### PR TITLE
Remove gulpfile trailing spaces

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -3,10 +3,10 @@ var initGulpTasks = require('react-component-gulp-tasks');
 
 /**
  * Tasks are added by the react-component-gulp-tasks package
- * 
+ *
  * See https://github.com/JedWatson/react-component-gulp-tasks
  * for documentation.
- * 
+ *
  * You can also add your own additional gulp tasks if you like.
  */
 


### PR DESCRIPTION
Fixed this:

```
$ npm run lint
 gulpfile.js
   6:3  error  Trailing spaces not allowed  no-trailing-spaces
   9:3  error  Trailing spaces not allowed  no-trailing-spaces
```
