### PR TITLE
Fix React double inclusion in the examples

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -16,7 +16,8 @@ var taskConfig = {
 		name: '<%= componentName %>',
 		dependencies: [
 			'classnames',
-			'react'
+			'react',
+			'react-dom'
 		],
 		lib: 'lib'
 	},


### PR DESCRIPTION
Hello Jed!
I love the generator, thank you so much.

I noticed a small issue probably a consequence of the upgrade to react 0.14.
One cannot use refs in the examples.js.

You can reproduce the problem quite easilly.
Just include a ref in examples.js:

``` javascript
var React = require('react');
var ReactDOM = require('react-dom');
var MyComponent = require('react-my-component');

var App = React.createClass({
    render () {
        return (
            <div>
                <MyComponent ref="test" />
            </div>
        );
    }
});

ReactDOM.render(<App />, document.getElementById('app'));
```

You then get the following error:

```
Uncaught Error: Invariant Violation: addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component's `render` method, or you have multiple copies of React loaded (details: https://fb.me/react-refs-must-have-owner).
```

Based on a comment you made elsewhere on github, I believe you already experienced this issue with browserify.
I hope the fix is correct!
